### PR TITLE
Fix Windows/Mac compilation by adding platform guards

### DIFF
--- a/Plugins/NeovimSourceCodeAccess/Source/Developer/NeovimSourceCodeAccess/Private/NeovimSourceCodeAccessor.cpp
+++ b/Plugins/NeovimSourceCodeAccess/Source/Developer/NeovimSourceCodeAccess/Private/NeovimSourceCodeAccessor.cpp
@@ -1,7 +1,13 @@
 #include "NeovimSourceCodeAccessor.h"
 #include "HAL/PlatformProcess.h"
 #include "Internationalization/Internationalization.h"
+#if PLATFORM_LINUX
 #include "Linux/LinuxPlatformProcess.h"
+#elif PLATFORM_WINDOWS
+#include "Windows/WindowsPlatformProcess.h"
+#elif PLATFORM_MAC
+#include "Mac/MacPlatformProcess.h"
+#endif
 #include "Logging/LogMacros.h"
 #include "Misc/Paths.h"
 


### PR DESCRIPTION
Hi!!
Love this plugin A LOT. Thank you for this so much ❤️
As I was trying to set things up on Mac & Windows I found a few bugs. Starting with this one just to say hi. If this looks ok, I'll send over a few more PR's.
Quick question: have you personally tested things on macOS? Because I went through a few communication bugs there (and some other weird quirks)
Anyway, hi and thank you!

This PR fixes a compilation issue on Windows and macOS where the plugin was including `Linux/LinuxPlatformProcess.h` unconditionally, causing a build error: `Cannot open include file: alloca.h`.

## Changes
Added platform guards to include the correct platform-specific header:
- Linux: `Linux/LinuxPlatformProcess.h`
- Windows: `Windows/WindowsPlatformProcess.h`
- Mac: `Mac/MacPlatformProcess.h`

This follows the standard pattern used throughout Unreal Engine for platform-specific includes.

## Testing
- ✅ Compiles successfully on Windows
- ✅ Compiles successfully on macOS
- ✅ Compiles successfully on Linux (unchanged behavior)